### PR TITLE
Fix disabled property type in jsonConfig table items

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,10 @@ Each DTU creates a device node using its serial number as ID (e.g. `hoymiles.0.4
 Cloud stations create aggregated device nodes (e.g. `hoymiles.0.station-12345.*`).
 
 ## Changelog
+### **WORK IN PROGRESS**
+- (@Eistee82) Fix disabled property type in jsonConfig table items (string, not boolean)
+- (@Eistee82) Add local repochecker script (`npm run test:repo`)
+
 ### 0.3.3 (2026-04-08)
 - (@Eistee82) Fix jsonConfig schema warnings: button color, remove unsupported table properties
 

--- a/admin/jsonConfig.json
+++ b/admin/jsonConfig.json
@@ -89,7 +89,7 @@
                     "type": "text",
                     "title": "deviceSerial",
                     "attr": "serial",
-                    "disabled": true,
+                    "disabled": "true",
                     "filter": false,
                     "sort": false,
                     "default": ""
@@ -98,7 +98,7 @@
                     "type": "checkbox",
                     "title": "deviceReachable",
                     "attr": "reachable",
-                    "disabled": true,
+                    "disabled": "true",
                     "width": "60px",
                     "filter": false,
                     "sort": false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -2556,15 +2556,15 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.6",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
-      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.14.0.tgz",
+      "integrity": "sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/balanced-match": {
@@ -7287,11 +7287,14 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "test": "npm run test:package && npm run test:unit",
     "prepare": "npm run build",
     "release": "release-script in npm this --hierarchical",
-    "translate": "translate-adapter"
+    "translate": "translate-adapter",
+    "test:repo": "npx --yes @iobroker/repochecker https://github.com/Eistee82/ioBroker.hoymiles --local"
   },
   "keywords": [
     "ioBroker",


### PR DESCRIPTION
## Summary
- Change `disabled: true` (boolean) to `disabled: "true"` (string) on serial and reachable table items
- Repochecker schema expects string expressions for `disabled`, not booleans (W5512)

## Test plan
- [ ] Serial column: still not editable after discover
- [ ] Reachable column: still not editable after discover

🤖 Generated with [Claude Code](https://claude.com/claude-code)