### PR TITLE
chore: remove npm prepare script (repochecker W0092)

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Cloud stations create aggregated device nodes (e.g. `hoymiles.0.station-12345.*`
 
 ## Changelog
 ### **WORK IN PROGRESS**
+- (@Eistee82) Packaging: removed the npm `prepare` install script — installs from GitHub now use the committed `build/` output directly, so no dev dependencies are downloaded onto the target system; npm releases are still built freshly via `prepublishOnly`
 - (@Eistee82) CI/test reliability: added a global Mocha timeout and switched the test TLS certificates to fast EC keys, so the adapter-tests no longer time out on loaded CI runners
 
 ### 0.4.0 (2026-07-17)

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "test:unit": "c8 --lines 80 --branches 70 --functions 80 mocha \"test/*.test.js\" --exit",
     "test:integration": "mocha test/integration.cjs --exit",
     "test": "npm run test:package && npm run test:unit",
-    "prepare": "npm run build",
+    "prepublishOnly": "npm run build",
     "release": "release-script in npm this --hierarchical",
     "translate": "translate-adapter",
     "test:repo": "npx --yes @iobroker/repochecker https://github.com/Eistee82/ioBroker.hoymiles --local"


### PR DESCRIPTION
## Summary
Removes the `prepare` lifecycle script from `package.json`, which the ioBroker repochecker flags as W0092. Raised by @mcm1957 in ioBroker/ioBroker.repositories#6346.

npm runs `prepare` on install, which pulls every devDependency (TypeScript, ESLint, Mocha, …) onto the target system when a user installs from GitHub. That is exactly what the warning is about.

The script is not needed for GitHub installability here: `build/` is committed to this repository and listed in the package.json `files` array, so an install from GitHub already ships the compiled output. `comm.nogit` deliberately stays unset — installing from GitHub remains supported for beta testers.

## Changes
- `package.json`: `prepare` → `prepublishOnly` (runs only on `npm publish`, so npm releases are still built from current sources)
- `README.md`: changelog entry under **WORK IN PROGRESS**

## Breaking Changes
None. A plain `npm install` in a dev checkout no longer builds automatically; `pretest` and the documented workflow still run `npm run build`.

## Test plan
- [x] `npm run build` clean
- [x] `npm run lint` clean (0 errors, 0 warnings)
- [x] `npm run test:package` — 57 passing
- [x] unit tests — 776 passing
- [x] `npm run test:repo` — W0092 gone, no new findings
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
